### PR TITLE
fix warning

### DIFF
--- a/src/SelectRes.h
+++ b/src/SelectRes.h
@@ -19,10 +19,10 @@
 #include <SFML/Audio.hpp>
 
 struct Resolution {
-  Resolution(int w, int h, char* i) : width(w), height(h), info(i) {}
+  Resolution(int w, int h, const char* i) : width(w), height(h), info(i) {}
   int width;
   int height;
-  char* info;
+  const char* info;
 };
 static const int num_resolutions = 5;
 const extern Resolution all_resolutions[num_resolutions];


### PR DESCRIPTION
Resolution() is initialized with a string constant, so info should be const too.

fixes
```
/tmp/MarbleMarcher/src/SelectRes.cpp:21:54: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
   Resolution(640, 360, "I don't have a dedicated GPU"),
                                                      ^
/tmp/MarbleMarcher/src/SelectRes.cpp:22:46: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
   Resolution(960, 540, "I have a low-end GPU"),
                                              ^
/tmp/MarbleMarcher/src/SelectRes.cpp:23:49: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
   Resolution(1280, 720, "I have a mid-range GPU"),
                                                 ^
/tmp/MarbleMarcher/src/SelectRes.cpp:24:48: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
   Resolution(1600, 900, "I have a high-end GPU"),
                                                ^
/tmp/MarbleMarcher/src/SelectRes.cpp:25:58: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
   Resolution(1920, 1080, "Will be fast enough someday...")

```