### PR TITLE
[linux] fix linking errors i had on my system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ add_executable(MarbleMarcher src/Main.cpp)
 target_link_libraries(MarbleMarcher
   MarbleMarcherSources
   Eigen3::Eigen
+  sfml-system
+  sfml-window
   sfml-graphics
   sfml-audio
   ${Boost_SYSTEM_LIBRARY}


### PR DESCRIPTION
i had some linking errors of dependencies of dependencies or so.
(ubuntu18.04 gcc7.3)